### PR TITLE
FIX: docker build and file permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM tinysun/wine-xpra
 MAINTAINER Han Sangjin "tinysun.net@gmail.com"
 
 # Install Git, Mercurial
-RUN apt-get install -y git mercurial
+RUN apt-get update && apt-get install -y git mercurial
 
 # Install Convert Tool
 RUN wget https://github.com/tinysun212/fast-export/archive/v1.0.zip -O /usr/local/etc/fast-export.zip
@@ -11,7 +11,8 @@ RUN ln -s fast-export-1.0  /opt/fast-export
 COPY hg2git  /usr/local/bin/
 
 
-COPY  startup.sh setup_env.sh /usr/local/bin/
+COPY startup.sh setup_env.sh /usr/local/bin/
+RUN bash -c "chmod +x /usr/local/bin/{hg2git,startup.sh,setup_env.sh}"
 
 EXPOSE 22
-CMD ["/usr/local/bin/startup.sh"]
+CMD ["/bin/bash", "/usr/local/bin/startup.sh"]

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -10,5 +10,5 @@ cat >> ~/.profile <<ENDPROFILE
 LANG=en_US.UTF-8
 export LANG
 
-cd Temp
+[ -d Temp ] && cd Temp
 ENDPROFILE


### PR DESCRIPTION
fxied:
1. docker build without `apt update` gives `E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/r/rsync/rsync_3.1.0-2ubuntu0.1_amd64.deb  404  Not Found [IP: 91.189.88.162 80]`

2. bash scripts added to image(by COPY) cant run directly whithout `bash `or `chmod +x`